### PR TITLE
Added readme content to page to replace long_description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Ferdinand Becker", email = "ferdinand.becker@btc-embedded.com"},
 ]
 
-version = "25.2.3"
+version = "25.2.3b1"
 
 license = "MIT"
 description="API wrapper for BTC EmbeddedPlatform REST API"
@@ -21,6 +21,7 @@ dependencies = [
     "pyyaml",
 ]
 
+readme = "README.md"
 
 classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Previous build file used the "long_description" field to provide a string description.

This commit instead adds the README.md content as the description for the page.

Example: https://pypi.org/project/btc-embedded/25.2.3b1/
