### PR TITLE
New version of btc-ep-test-automation skill v0.4.0

### DIFF
--- a/.agent/skills/btc-ep-test-automation/manifest.yaml
+++ b/.agent/skills/btc-ep-test-automation/manifest.yaml
@@ -1,5 +1,5 @@
 name: btc-ep-test-automation
-version: 0.3.0
+version: 0.4.0
 description: "Automate BTC EmbeddedPlatform test workflows using Python and the btc_embedded REST API wrapper."
 entry: SKILL.md
 references:

--- a/.agent/skills/btc-ep-test-automation/references/examples/ccode_rbt.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/ccode_rbt.py
@@ -3,7 +3,6 @@ Example: C-Code RBT Test Automation
 """
 
 import glob
-import logging
 import os
 import sys
 from datetime import datetime
@@ -18,16 +17,6 @@ TESTCASES_DIR = os.path.abspath('test/testcases')
 EPP_FILE = os.path.join(RESULTS_DIR, 'test_project.epp')
 
 os.makedirs(RESULTS_DIR, exist_ok=True)
-
-# Set up logging to both console and file before creating EPRestApi so the
-# library skips adding its own console handler (it only adds one when none exist).
-logger = logging.getLogger('btc_embedded')
-logger.setLevel(logging.INFO)
-fmt = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-for handler in [logging.StreamHandler(),
-                logging.FileHandler(os.path.join(RESULTS_DIR, 'test_run.log'))]:
-    handler.setFormatter(fmt)
-    logger.addHandler(handler)
 
 start_time = datetime.now()
 ep = None
@@ -62,7 +51,7 @@ try:
     print_rbt_results(rbt_result, rbt_coverage)
 
     # 5. Generate report and export artifacts
-    report = ep.post(f'scopes/{scope_uid}/project-report',
+    report = ep.post(f'scopes/{scope_uid}/project-report?template-name=rbt-sil-only',
                      message='Creating test report')
     ep.post(f'reports/{report["uid"]}',
             {'exportPath': RESULTS_DIR, 'newName': 'test_report'},
@@ -82,10 +71,10 @@ try:
         output_file=os.path.join(RESULTS_DIR, 'test_results.xml')
     )
 
-    logger.info("Test execution completed successfully.")
+    print("Test execution completed successfully.")
 
 except Exception as e:
-    logger.error(f"Test execution failed: {e}")
+    print(f"Test execution failed: {e}")
     sys.exit(1)
 finally:
     if ep:

--- a/.agent/skills/btc-ep-test-automation/references/examples/embeddedcoder_rbt_b2b.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/embeddedcoder_rbt_b2b.py
@@ -3,7 +3,6 @@ Example: EmbeddedCoder RBT + B2B Test Automation
 """
 
 import glob
-import logging
 import os
 import sys
 from datetime import datetime
@@ -19,15 +18,6 @@ EC_INIT_SCRIPT = os.path.abspath('model/init_Wrapper_my_ec_model.m')
 EPP_FILE = os.path.join(RESULTS_DIR, 'my_ec_model.epp')
 
 os.makedirs(RESULTS_DIR, exist_ok=True)
-
-# Set up logging
-logger = logging.getLogger('btc_embedded')
-logger.setLevel(logging.INFO)
-fmt = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-for handler in [logging.StreamHandler(),
-                logging.FileHandler(os.path.join(RESULTS_DIR, 'test_run.log'))]:
-    handler.setFormatter(fmt)
-    logger.addHandler(handler)
 
 start_time = datetime.now()
 ep = None
@@ -105,10 +95,10 @@ try:
         output_file=os.path.join(RESULTS_DIR, 'test_results.xml')
     )
     
-    logger.info("Test execution completed successfully.")
+    print("Test execution completed successfully.")
 
 except Exception as e:
-    logger.error(f"Test execution failed: {e}")
+    print(f"Test execution failed: {e}")
     sys.exit(1)
 finally:
     if ep:

--- a/.agent/skills/btc-ep-test-automation/references/examples/simulink_rbt_mil_only.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/simulink_rbt_mil_only.py
@@ -3,7 +3,6 @@ Example: Simulink RBT MIL Only Test Automation
 """
 
 import glob
-import logging
 import os
 import sys
 from datetime import datetime
@@ -18,15 +17,6 @@ EPP_FILE = os.path.abspath('my_sl_model.epp')
 RESULTS_EPP = os.path.join(RESULTS_DIR, 'my_sl_model.epp')
 
 os.makedirs(RESULTS_DIR, exist_ok=True)
-
-# Set up logging
-logger = logging.getLogger('btc_embedded')
-logger.setLevel(logging.INFO)
-fmt = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-for handler in [logging.StreamHandler(),
-                logging.FileHandler(os.path.join(RESULTS_DIR, 'test_run.log'))]:
-    handler.setFormatter(fmt)
-    logger.addHandler(handler)
 
 start_time = datetime.now()
 ep = None
@@ -90,10 +80,10 @@ try:
         output_file=os.path.join(RESULTS_DIR, 'test_results.xml')
     )
     
-    logger.info("Test execution completed successfully.")
+    print("Test execution completed successfully.")
 
 except Exception as e:
-    logger.error(f"Test execution failed: {e}")
+    print(f"Test execution failed: {e}")
     sys.exit(1)
 finally:
     if ep:

--- a/.agent/skills/btc-ep-test-automation/references/examples/targetlink_rbt_b2b.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/targetlink_rbt_b2b.py
@@ -3,7 +3,6 @@ Example: TargetLink RBT + B2B Test Automation
 """
 
 import glob
-import logging
 import os
 import sys
 from datetime import datetime
@@ -19,15 +18,6 @@ TL_INIT_SCRIPT = os.path.abspath('model/init.m')
 EPP_FILE = os.path.join(RESULTS_DIR, 'my_tl_model.epp')
 
 os.makedirs(RESULTS_DIR, exist_ok=True)
-
-# Set up logging
-logger = logging.getLogger('btc_embedded')
-logger.setLevel(logging.INFO)
-fmt = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-for handler in [logging.StreamHandler(),
-                logging.FileHandler(os.path.join(RESULTS_DIR, 'test_run.log'))]:
-    handler.setFormatter(fmt)
-    logger.addHandler(handler)
 
 start_time = datetime.now()
 ep = None
@@ -105,10 +95,10 @@ try:
         output_file=os.path.join(RESULTS_DIR, 'test_results.xml')
     )
     
-    logger.info("Test execution completed successfully.")
+    print("Test execution completed successfully.")
 
 except Exception as e:
-    logger.error(f"Test execution failed: {e}")
+    print(f"Test execution failed: {e}")
     sys.exit(1)
 finally:
     if ep:


### PR DESCRIPTION
- Bumped skill version from 0.3.0 to 0.4.0 in manifest.yaml.
- Removed manual logging setup (btc_embedded logger, StreamHandler, FileHandler) from all four example scripts, simplifying boilerplate and letting the library manage its own logging.
- Replaced `logger.info` and `logger.error` calls with plain `print` statements for success/failure output, reducing the dependency on the logging module.
- Removed the `import logging` statement from all four example files as it is no longer needed.
- Fixed the project-report endpoint in `ccode_rbt.py` to include the `?template-name=rbt-sil-only` query parameter, ensuring the correct report template is used.