### PR TITLE
Added Formal Methods support

### DIFF
--- a/.agent/skills/btc-ep-test-automation/SKILL.md
+++ b/.agent/skills/btc-ep-test-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: btc-ep-test-automation
-description: Automate BTC EmbeddedPlatform test workflows by writing Python scripts using the btc_embedded module. Use this skill whenever someone needs to create, fix, or extend a Python script that interacts with the BTC EmbeddedPlatform REST API — including running Requirements-Based Tests (RBT), Back-to-Back Tests (B2B), importing architectures or test cases, generating reports, or saving profiles. Also use this skill when someone asks about btc_embedded API endpoints, request/response formats, or correct usage of EPRestApi.
+description: Automate BTC EmbeddedPlatform test workflows by writing Python scripts using the btc_embedded module. Use this skill whenever someone needs to create, fix, or extend a Python script that interacts with the BTC EmbeddedPlatform REST API — including running Requirements-Based Tests (RBT), Back-to-Back Tests (B2B), Formal Test, Formal Verification, importing architectures/test cases/specifications, generating reports, or saving profiles. Also use this skill when someone asks about btc_embedded API endpoints, request/response formats, or correct usage of EPRestApi.
 ---
 
 # BTC EmbeddedPlatform Test Automation
@@ -19,8 +19,55 @@ For common workflows, refer to these ready-to-use example scripts in `references
 - **`migration_suite_mbd.py`** — Multi-model migration suite using `migration_suite_source()` + `migration_suite_target()`. Two-phase pattern for Docker-based environment testing. MATLAB R2024b, EP 25.3p0.
 - **`migration_test_ccode.py`** — Custom migration test for a single C-code component. Defines `migration_source_ccode()` and `migration_target_ccode()` functions, then calls them. EP 25.3p0.
 - **`migration_suite_ccode.py`** — Custom migration suite for multiple C-code components. Defines `migration_suite_source_ccode()` and `migration_suite_target_ccode()` which loop over components calling the source/target functions. Two-phase pattern for Docker-based environment testing. EP 25.3p0.
+- **`formal_test_new_profile.py`** — C-code Formal Test workflow that starts with a new profile, imports architecture + test cases + SPEC files, executes SIL test execution and formal test, then reports formal requirement coverage/status.
+- **`formal_verification_new_profile.py`** — C-code Formal Verification workflow that starts with a new profile, imports architecture + SPEC files, creates and executes proofs, then reports proof outcomes and formal verification report.
+- **`formal_test_verification_existing_profile.py`** — Combined Formal Test + Formal Verification workflow that starts from an existing profile, updates architecture, assumes tests/specs are already present, then runs both analyses and exports reports.
 
 These examples follow all ground rules below and can serve as templates for custom workflows.
+
+## Formal Methods Overview
+
+Formal Methods in BTC EmbeddedPlatform use Formal Specifications (SPEC) to unambiguously define requirement intent in machine-readable form.
+
+### Formal Specification Process
+
+1. Identify key requirements and constraints from the natural-language requirement.
+2. Create macros that map requirement phrases to placeholders in the formalized requirement.
+3. Define each macro precisely using the SUT interface and signal semantics.
+4. Use these macros in a universal pattern (trigger, action, timing, exit condition, etc.).
+
+Formal Specification helps reveal ambiguities and inconsistencies and produces Formal Requirements (Formal Specs).
+
+### Validation and Verification Modes
+
+- **Requirements coverage (formal):** checks whether tests truly exercise formal trigger conditions and whether expected actions are observed according to the formalized requirement.
+- **Formal Verification:** proves whether the SUT satisfies formal requirements.
+- **Formal Test:** checks behavior against formal requirements on top of existing test executions.
+
+### Formal Test Workflow
+
+1. Choice node:
+    - 1a. Create a profile, import architecture, import test cases and SPEC files.
+    - 1b. Load a profile, update architecture, and if test/spec files exist in workspace ask whether to import.
+2. Execute tests on SIL.
+3. Execute formal test.
+4. Report results (test results, code coverage, formal test results, formal requirements coverage).
+5. Create reports and save artifacts.
+
+### Formal Verification Workflow
+
+1. Choice node:
+    - 1a. Create a profile, import architecture, import SPEC files.
+    - 1b. Load a profile, update architecture, and if SPEC files exist in workspace ask whether to import.
+2. Execute proofs for each formal requirement.
+3. Report results (proof results, formal requirements coverage).
+4. Create reports and save artifacts.
+
+### Formal Requirement Status (FR Status SIL)
+
+- **Fulfilled:** trigger observed and specified action occurred.
+- **Violated:** trigger observed but specified action did not occur.
+- **Inconclusive:** trigger never occurred in the executed tests.
 
 ## User Interaction Pattern
 
@@ -50,10 +97,23 @@ Use the following required decision prompts when applicable:
     - otherwise -> create a new profile and import architecture based on discovered files (`*.slx` for model-based, `CodeModel.xml` for C-code)
     Do not ask this as a default decision unless multiple candidate profiles exist and a choice is required.
 
+    **Profile Format Reference:**
+    There are two types of profiles (test projects):
+    - **EPP**: a binary blob (zip file with metadata and object-db files) containing the full database.
+    - **EPX**: a JSON file (`profile-name.epx`) + a companion folder (`profile-name_btcdata`) with configuration and test data in readable, git-friendly formats (mostly JSON, some legacy XMLs).
+    
+    When working with EPX profiles, do not attempt to import artifacts from the `profile-name_btcdata` folder—these files are automatically imported by BTC when an `*.epx` profile is loaded.
+
 - **RBT project without an existing test project:**
     Auto-discover and import test cases when possible:
     - if a folder contains `*.tc` or `*.tc.json`, import them directly (exclude `*.ui_settings.tc*`)
     Ask only if no test case files can be found.
+
+- **Formal Methods project (Formal Test and/or Formal Verification):**
+    Auto-discover and import formal specification files when possible:
+    - if a folder contains `*.spec`, import all such files
+    If Formal Test is requested, also auto-discover test cases as in the RBT rule above.
+    Ask only if no required artifacts are found (for example, no SPEC files for Formal Verification, or no test cases for Formal Test).
 
 - **Artifacts and output locations:**
     Propose exporting standard artifacts into a `results/` folder (`test_report.html`, profile `*.epp`, JUnit XML), then ask:
@@ -93,6 +153,56 @@ Use the following required decision prompts when applicable:
     Include: files ending with `.tc.json`. Exclude: files ending with `.ui_settings.tc.json`. Do not include all `*.json` files — `*.tcm.json` are test macros imported automatically if referenced by test cases.
 
     When there are `.tc` files instead of `*.tc.json` files, include `*.tc` files and exclude `*.ui_settings.tc` files similarly.
+
+- **When importing formal specifications, use the SPEC import endpoint and absolute paths:**
+    ```python
+    spec_files = sorted(glob.glob(os.path.join(SPECS_DIR, '*.spec')))
+    for spec_file in spec_files:
+        ep.post(
+            'specifications-import',
+            {'specPath': spec_file, 'scopeId': scope_uid, 'optionParam': 'OVERWRITE'},
+            message=f'Importing formal specification: {os.path.basename(spec_file)}',
+        )
+    ```
+
+- **For Formal Test workflows, execute SIL test execution before formal test and then query formal test status:**
+    ```python
+    ep.post(
+        f'scopes/{scope_uid}/test-execution-rbt',
+        {'execConfigNames': ['SIL']},
+        message='Running Requirements-Based Tests (SIL) before Formal Test',
+    )
+    ep.post('execute-formal-test', message='Executing formal test')
+    fr_status = ep.get(f'scopes/{scope_uid}/formal-test-results?execution-config-name=SIL')
+    ```
+
+- **For Formal Verification workflows, create and execute proofs for formal requirements in the scope:**
+    ```python
+    formal_requirements = ep.get(f'scopes/{scope_uid}/formal-requirements')
+    proof_uids = [ep.post(f"proofs/{fr['uid']}", message='Creating proof')['uid']
+                  for fr in formal_requirements]
+    proof_results = ep.post(
+        'proofs/execute',
+        {'proofUIDs': proof_uids, 'strategy': 'BALANCED'},
+        message='Executing proofs for formal verification',
+    )
+    ```
+
+- **Create dedicated reports for formal workflows and export them via `/reports/{uid}`:**
+    ```python
+    formal_test_report = ep.post(
+        f'scopes/{scope_uid}/formal-test-reports',
+        {'executionConfigNames': ['SIL']},
+        message='Creating formal test report',
+    )
+    formal_verification_report = ep.post(
+        f'scopes/{scope_uid}/formal-verification-reports',
+        message='Creating formal verification report',
+    )
+    ep.post(f'reports/{formal_test_report["uid"]}',
+            {'exportPath': RESULTS_DIR, 'newName': 'formal_test_report'},
+            message='Exporting formal test report')
+    ```
 
 - **Add `message=` to `ep.post`, `ep.put`, and `ep.delete` calls** so runtime logs clearly describe each step. `ep.get(...)` calls do not need messages (they are fast). Message text should state intent, for example:
     ```python

--- a/.agent/skills/btc-ep-test-automation/manifest.yaml
+++ b/.agent/skills/btc-ep-test-automation/manifest.yaml
@@ -1,5 +1,5 @@
 name: btc-ep-test-automation
-version: 0.4.0
+version: 0.5.0
 description: "Automate BTC EmbeddedPlatform test workflows using Python and the btc_embedded REST API wrapper."
 entry: SKILL.md
 references:

--- a/.agent/skills/btc-ep-test-automation/references/examples/formal_test_new_profile.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/formal_test_new_profile.py
@@ -1,0 +1,144 @@
+"""
+Example: Formal Test Workflow (new profile)
+
+Workflow:
+1. Create a new profile and import C-code architecture
+2. Import test cases and formal specifications (*.spec)
+3. Run SIL test execution and formal test
+4. Create/export reports and save profile
+"""
+
+import glob
+import os
+import sys
+
+from btc_embedded import EPRestApi
+from btc_embedded.util import print_rbt_results
+
+# Configuration
+RESULTS_DIR = os.path.abspath('results')
+CODE_MODEL_XML = os.path.abspath('test/CodeModel.xml')
+TESTCASES_DIR = os.path.abspath('test/testcases')
+SPECS_DIR = os.path.abspath('specs')
+EPP_FILE = os.path.join(RESULTS_DIR, 'formal_test_project.epp')
+
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+
+def collect_test_case_files(testcases_dir):
+    tc_json_files = sorted(
+        p for p in glob.glob(os.path.join(testcases_dir, '*.tc.json'))
+        if not p.endswith('.ui_settings.tc.json')
+    )
+    tc_files = sorted(
+        p for p in glob.glob(os.path.join(testcases_dir, '*.tc'))
+        if not p.endswith('.ui_settings.tc')
+    )
+    return tc_json_files + tc_files
+
+
+def print_formal_test_status(result):
+    print('\nFormal test summary')
+    print(f"  Coverage: {result.get('coverage', 'UNKNOWN')}")
+    print(f"  Status:   {result.get('status', 'UNKNOWN')}")
+    fr_results = result.get('formalRequirementResults', [])
+    print(f"  Formal requirements: {len(fr_results)}")
+
+    for fr in fr_results:
+        fr_name = fr.get('formalRequirmentName', '<unnamed>')
+        fr_uid = fr.get('formalRequirementUid', '<no-uid>')
+        fr_coverage = fr.get('coverage', 'UNKNOWN')
+        fr_status = fr.get('status', 'UNKNOWN')
+        print(f"    - {fr_name} ({fr_uid}): status={fr_status}, coverage={fr_coverage}")
+
+
+ep = None
+
+try:
+    ep = EPRestApi()
+    ep.set_compiler()
+
+    # 1. Create fresh profile and import architecture
+    ep.post('profiles', message='Creating a new profile')
+    ep.post(
+        'architectures/ccode',
+        {'modelFile': CODE_MODEL_XML},
+        message='Importing C-code architecture',
+    )
+
+    scopes = ep.get('scopes')
+    scope_uid = scopes[0]['uid']
+
+    # 2. Import test cases
+    tc_files = collect_test_case_files(TESTCASES_DIR)
+    if not tc_files:
+        raise RuntimeError(f'No test case files found in {TESTCASES_DIR}')
+
+    ep.put(
+        'test-cases-rbt',
+        {'paths': tc_files},
+        message='Importing test cases for Formal Test workflow',
+    )
+
+    # 3. Import formal specifications (*.spec)
+    spec_files = sorted(glob.glob(os.path.join(SPECS_DIR, '*.spec')))
+    if not spec_files:
+        raise RuntimeError(f'No .spec files found in {SPECS_DIR}')
+
+    for spec_file in spec_files:
+        ep.post(
+            'specifications-import',
+            {
+                'specPath': spec_file,
+                'scopeId': scope_uid,
+                'optionParam': 'OVERWRITE',
+            },
+            message=f'Importing formal specification: {os.path.basename(spec_file)}',
+        )
+
+    # 4. Run SIL test execution before formal test
+    rbt_result = ep.post(
+        f'scopes/{scope_uid}/test-execution-rbt',
+        {'execConfigNames': ['SIL']},
+        message='Running Requirements-Based Tests (SIL)',
+    )
+    rbt_coverage = ep.get(f'scopes/{scope_uid}/coverage-results-rbt')
+    print_rbt_results(rbt_result, rbt_coverage)
+
+    ep.post('execute-formal-test', message='Executing formal test')
+    formal_test_results = ep.get(
+        f'scopes/{scope_uid}/formal-test-results?execution-config-name=SIL'
+    )
+    print_formal_test_status(formal_test_results)
+
+    # 5. Create and export reports
+    test_report = ep.post(
+        f'scopes/{scope_uid}/project-report?template-name=rbt-sil-only',
+        message='Creating test report',
+    )
+    ep.post(
+        f'reports/{test_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'test_report'},
+        message='Exporting test report',
+    )
+
+    formal_test_report = ep.post(
+        f'scopes/{scope_uid}/formal-test-reports',
+        {'executionConfigNames': ['SIL']},
+        message='Creating formal test report',
+    )
+    ep.post(
+        f'reports/{formal_test_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'formal_test_report'},
+        message='Exporting formal test report',
+    )
+
+    ep.put('profiles', {'path': EPP_FILE}, message='Saving profile')
+    print('Formal Test workflow completed successfully.')
+
+except Exception as exc:
+    print(f'Formal Test workflow failed: {exc}')
+    sys.exit(1)
+finally:
+    if ep:
+        ep.close_application()

--- a/.agent/skills/btc-ep-test-automation/references/examples/formal_test_verification_existing_profile.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/formal_test_verification_existing_profile.py
@@ -1,0 +1,175 @@
+"""
+Example: Combined Formal Test + Formal Verification (existing profile)
+
+Assumptions:
+- Existing profile already contains test cases and formal specifications.
+
+Workflow:
+1. Load existing profile and run architecture update
+2. Run SIL test execution and formal test
+3. Create/execute proofs for formal verification
+4. Create/export reports and save updated profile
+"""
+
+import os
+import sys
+
+from btc_embedded import EPRestApi
+from btc_embedded.util import print_rbt_results
+
+# Configuration
+RESULTS_DIR = os.path.abspath('results')
+EPP_FILE = os.path.abspath('existing_project.epp')
+RESULTS_EPP = os.path.join(RESULTS_DIR, 'existing_project_formal_results.epp')
+
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+
+def print_formal_test_status(result):
+    print('\nFormal test summary')
+    print(f"  Coverage: {result.get('coverage', 'UNKNOWN')}")
+    print(f"  Status:   {result.get('status', 'UNKNOWN')}")
+    fr_results = result.get('formalRequirementResults', [])
+    print(f"  Formal requirements: {len(fr_results)}")
+
+    for fr in fr_results:
+        fr_name = fr.get('formalRequirmentName', '<unnamed>')
+        fr_uid = fr.get('formalRequirementUid', '<no-uid>')
+        fr_coverage = fr.get('coverage', 'UNKNOWN')
+        fr_status = fr.get('status', 'UNKNOWN')
+        print(f"    - {fr_name} ({fr_uid}): status={fr_status}, coverage={fr_coverage}")
+
+
+def print_proof_summary(proof_uids, proof_name_by_uid, detailed_results_by_uid):
+    print('\nFormal verification summary')
+    print(f'  Proof count: {len(proof_uids)}')
+
+    for proof_uid in proof_uids:
+        proof_name = proof_name_by_uid.get(proof_uid, '<unnamed-proof>')
+        details = detailed_results_by_uid.get(proof_uid, [])
+
+        if not details:
+            print(f'    - {proof_name} ({proof_uid}): no detailed result available')
+            continue
+
+        latest = details[-1]
+        result = latest.get('proofResult', 'UNKNOWN')
+        termination = latest.get('terminationReason', 'UNKNOWN')
+        steps = latest.get('steps', 'UNKNOWN')
+        print(
+            f'    - {proof_name} ({proof_uid}): '
+            f'result={result}, termination={termination}, steps={steps}'
+        )
+
+
+ep = None
+
+try:
+    ep = EPRestApi()
+    ep.set_compiler()
+
+    # 1. Load profile and update architecture
+    ep.get(f'openprofile?path={EPP_FILE}')
+    ep.put('architectures', message='Running architecture update on existing profile')
+
+    scopes = ep.get('scopes')
+    scope_uid = scopes[0]['uid']
+
+    test_cases = ep.get('test-cases-rbt')
+    if not test_cases:
+        raise RuntimeError('Existing profile does not contain test cases for Formal Test')
+
+    formal_requirements = ep.get(f'scopes/{scope_uid}/formal-requirements')
+    if not formal_requirements:
+        raise RuntimeError('Existing profile does not contain formal requirements/specifications')
+
+    # 2. Execute SIL RBT first, then formal test
+    rbt_result = ep.post(
+        f'scopes/{scope_uid}/test-execution-rbt',
+        {'execConfigNames': ['SIL']},
+        message='Running Requirements-Based Tests (SIL)',
+    )
+    rbt_coverage = ep.get(f'scopes/{scope_uid}/coverage-results-rbt')
+    print_rbt_results(rbt_result, rbt_coverage)
+
+    ep.post('execute-formal-test', message='Executing formal test')
+    formal_test_results = ep.get(
+        f'scopes/{scope_uid}/formal-test-results?execution-config-name=SIL'
+    )
+    print_formal_test_status(formal_test_results)
+
+    # 3. Ensure proofs exist (create if needed), then execute proofs
+    existing_proofs = ep.get('proofs')
+    proof_uids = [proof['uid'] for proof in existing_proofs]
+    proof_name_by_uid = {
+        proof['uid']: proof.get('name', '<unnamed-proof>')
+        for proof in existing_proofs
+    }
+
+    if not proof_uids:
+        for formal_requirement in formal_requirements:
+            fr_uid = formal_requirement['uid']
+            fr_name = formal_requirement.get('name', '<unnamed-formal-requirement>')
+            proof = ep.post(f'proofs/{fr_uid}', message=f'Creating proof for {fr_name}')
+            proof_uid = proof['uid']
+            proof_uids.append(proof_uid)
+            proof_name_by_uid[proof_uid] = proof.get('name', fr_name)
+
+    ep.post(
+        'proofs/execute',
+        {
+            'proofUIDs': proof_uids,
+            'strategy': 'BALANCED',
+            'maxNumberOfThreads': -1,
+        },
+        message='Executing proofs for formal verification',
+    )
+
+    detailed_results_by_uid = {}
+    for proof_uid in proof_uids:
+        detailed_results_by_uid[proof_uid] = ep.get(
+            f'proofs/{proof_uid}/detailed-proof-results'
+        )
+    print_proof_summary(proof_uids, proof_name_by_uid, detailed_results_by_uid)
+
+    # 4. Create and export reports
+    test_report = ep.post(
+        f'scopes/{scope_uid}/project-report?template-name=rbt-sil-only',
+        message='Creating test report',
+    )
+    ep.post(
+        f'reports/{test_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'test_report'},
+        message='Exporting test report',
+    )
+
+    formal_test_report = ep.post(
+        f'scopes/{scope_uid}/formal-test-reports',
+        {'executionConfigNames': ['SIL']},
+        message='Creating formal test report',
+    )
+    ep.post(
+        f'reports/{formal_test_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'formal_test_report'},
+        message='Exporting formal test report',
+    )
+
+    formal_verification_report = ep.post(
+        f'scopes/{scope_uid}/formal-verification-reports',
+        message='Creating formal verification report',
+    )
+    ep.post(
+        f'reports/{formal_verification_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'formal_verification_report'},
+        message='Exporting formal verification report',
+    )
+
+    ep.put('profiles', {'path': RESULTS_EPP}, message='Saving updated profile')
+    print('Combined Formal Test + Formal Verification workflow completed successfully.')
+
+except Exception as exc:
+    print(f'Combined formal workflow failed: {exc}')
+    sys.exit(1)
+finally:
+    if ep:
+        ep.close_application()

--- a/.agent/skills/btc-ep-test-automation/references/examples/formal_verification_new_profile.py
+++ b/.agent/skills/btc-ep-test-automation/references/examples/formal_verification_new_profile.py
@@ -1,0 +1,133 @@
+"""
+Example: Formal Verification Workflow (new profile)
+
+Workflow:
+1. Create a new profile and import C-code architecture
+2. Import formal specifications (*.spec)
+3. Create proofs for all formal requirements and execute them
+4. Create/export formal verification report and save profile
+"""
+
+import glob
+import os
+import sys
+
+from btc_embedded import EPRestApi
+
+# Configuration
+RESULTS_DIR = os.path.abspath('results')
+CODE_MODEL_XML = os.path.abspath('test/CodeModel.xml')
+SPECS_DIR = os.path.abspath('specs')
+EPP_FILE = os.path.join(RESULTS_DIR, 'formal_verification_project.epp')
+
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+
+def print_proof_summary(proof_uids, proof_name_by_uid, detailed_results_by_uid):
+    print('\nFormal verification summary')
+    print(f'  Proof count: {len(proof_uids)}')
+
+    for proof_uid in proof_uids:
+        proof_name = proof_name_by_uid.get(proof_uid, '<unnamed-proof>')
+        details = detailed_results_by_uid.get(proof_uid, [])
+
+        if not details:
+            print(f'    - {proof_name} ({proof_uid}): no detailed result available')
+            continue
+
+        latest = details[-1]
+        result = latest.get('proofResult', 'UNKNOWN')
+        termination = latest.get('terminationReason', 'UNKNOWN')
+        steps = latest.get('steps', 'UNKNOWN')
+        print(
+            f'    - {proof_name} ({proof_uid}): '
+            f'result={result}, termination={termination}, steps={steps}'
+        )
+
+
+ep = None
+
+try:
+    ep = EPRestApi()
+    ep.set_compiler()
+
+    # 1. Create fresh profile and import architecture
+    ep.post('profiles', message='Creating a new profile')
+    ep.post(
+        'architectures/ccode',
+        {'modelFile': CODE_MODEL_XML},
+        message='Importing C-code architecture',
+    )
+
+    scopes = ep.get('scopes')
+    scope_uid = scopes[0]['uid']
+
+    # 2. Import formal specifications (*.spec)
+    spec_files = sorted(glob.glob(os.path.join(SPECS_DIR, '*.spec')))
+    if not spec_files:
+        raise RuntimeError(f'No .spec files found in {SPECS_DIR}')
+
+    for spec_file in spec_files:
+        ep.post(
+            'specifications-import',
+            {
+                'specPath': spec_file,
+                'scopeId': scope_uid,
+                'optionParam': 'OVERWRITE',
+            },
+            message=f'Importing formal specification: {os.path.basename(spec_file)}',
+        )
+
+    formal_requirements = ep.get(f'scopes/{scope_uid}/formal-requirements')
+    if not formal_requirements:
+        raise RuntimeError('No formal requirements are available after SPEC import')
+
+    # 3. Create proofs and execute them
+    proof_uids = []
+    proof_name_by_uid = {}
+    for formal_requirement in formal_requirements:
+        fr_uid = formal_requirement['uid']
+        fr_name = formal_requirement.get('name', '<unnamed-formal-requirement>')
+        proof = ep.post(f'proofs/{fr_uid}', message=f'Creating proof for {fr_name}')
+        proof_uid = proof['uid']
+        proof_uids.append(proof_uid)
+        proof_name_by_uid[proof_uid] = proof.get('name', fr_name)
+
+    ep.post(
+        'proofs/execute',
+        {
+            'proofUIDs': proof_uids,
+            'strategy': 'BALANCED',
+            'maxNumberOfThreads': -1,
+        },
+        message='Executing proofs for formal verification',
+    )
+
+    detailed_results_by_uid = {}
+    for proof_uid in proof_uids:
+        detailed_results_by_uid[proof_uid] = ep.get(
+            f'proofs/{proof_uid}/detailed-proof-results'
+        )
+
+    print_proof_summary(proof_uids, proof_name_by_uid, detailed_results_by_uid)
+
+    # 4. Create and export formal verification report
+    formal_verification_report = ep.post(
+        f'scopes/{scope_uid}/formal-verification-reports',
+        message='Creating formal verification report',
+    )
+    ep.post(
+        f'reports/{formal_verification_report["uid"]}',
+        {'exportPath': RESULTS_DIR, 'newName': 'formal_verification_report'},
+        message='Exporting formal verification report',
+    )
+
+    ep.put('profiles', {'path': EPP_FILE}, message='Saving profile')
+    print('Formal Verification workflow completed successfully.')
+
+except Exception as exc:
+    print(f'Formal Verification workflow failed: {exc}')
+    sys.exit(1)
+finally:
+    if ep:
+        ep.close_application()


### PR DESCRIPTION
- Added Formal Test and Formal Verification support to the skill, including full workflow documentation (spec import, proof creation/execution, result reporting) and updated decision prompts for auto-discovering `.spec` files.
- Added three new example scripts: `formal_test_new_profile.py`, `formal_verification_new_profile.py`, and `formal_test_verification_existing_profile.py`, covering all combinations of new/existing profiles and test/verification workflows.
- Updated the skill description to explicitly mention Formal Test, Formal Verification, and specification import as covered use cases.
- Added a profile format reference (EPP vs EPX) to the decision prompt section, clarifying that EPX companion folder artifacts should not be manually imported.
- Bumped skill version from 0.4.0 to 0.5.0.